### PR TITLE
Add variable memory setting

### DIFF
--- a/lib/karabast-main-stack.ts
+++ b/lib/karabast-main-stack.ts
@@ -10,7 +10,7 @@ import { DockerImageAsset, Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { TableV2 } from 'aws-cdk-lib/aws-dynamodb';
 import { Secret as SecretsManager } from 'aws-cdk-lib/aws-secretsmanager';
 
-const CONTAINER_MEMORY_MIB = 4096;
+const CONTAINER_MEMORY_MIB = 6144;
 
 interface KarabastMainStackProps extends StackProps {
   ddbTable: TableV2;


### PR DESCRIPTION
Added a parameter variable for controlling how much memory to allocate to the node. Also sets an environment variable to control the nodejs heap size, setting it at 1GB less than the total container memory